### PR TITLE
ci: add Prettier format check workflow using GitHub Actions

### DIFF
--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  format:
+    name: Format Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - uses: pnpm/action-setup@v4
+        with:
+          version: latest
+      - run: pnpm install
+      - name: Prettier — check formatting
+        run: pnpm run format:check
+

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,5 @@
+node_modules
+.next
+public
+*.json
+*.md

--- a/.prettierrc 
+++ b/.prettierrc 
@@ -1,0 +1,8 @@
+{
+  "semi": true,
+  "singleQuote": true,
+  "trailingComma": "all",
+  "printWidth": 100,
+  "tabWidth": 2,
+  "arrowParens": "always"
+}


### PR DESCRIPTION
## Summary
Adds a GitHub Actions workflow to enforce consistent code formatting using Prettier on every pull request.

## Changes
- Added CI workflow (`.github/workflows/format.yaml`) to run Prettier format checks
- Configured workflow to trigger on pull requests to `main`
- Added `.prettierrc` for consistent formatting rules
- Added `.prettierignore` to exclude non-relevant files from formatting

## Why
Ensures all incoming code follows a consistent style automatically, improving code readability and preventing formatting-related diffs in future PRs.

## Impact
- No functional changes
- Fails CI if code is not properly formatted

## Notes
Developers can fix formatting locally using:
```bash
pnpm run format